### PR TITLE
chore: update v0.3.2

### DIFF
--- a/Formula/gear.rb
+++ b/Formula/gear.rb
@@ -4,7 +4,7 @@ class Gear < Formula
   desc "Computational Component of Polkadot Network"
   homepage "https://github.com/gear-tech/gear"
   license "GPL-3.0-or-later"
-  version "0.2.1"
+  version "0.3.2"
 
   livecheck do
     url "https://get.gear.rs"
@@ -13,13 +13,13 @@ class Gear < Formula
 
   stable do
     on_arm do
-      url "https://get.gear.rs/gear-v0.2.1-aarch64-apple-darwin.tar.xz"
-      sha256 "f0ad57365da3ecc483cc42fc3592afdcbcf9aac3ec0ffef36aa3878b75f6b3a0"
+      url "https://get.gear.rs/gear-v0.3.2-aarch64-apple-darwin.tar.xz"
+      sha256 "bfbd45b3e5f5577f873c8da36e2a2b67a7b7f835c652736594869344749b0e65"
     end
 
     on_intel do
-      url "https://get.gear.rs/gear-v0.2.1-x86_64-apple-darwin.tar.xz"
-      sha256 "2c865a571dc4dfafa72af1b8554ec9f8603995be50eedf621a2d8002eff57042"
+      url "https://get.gear.rs/gear-v0.3.2-x86_64-apple-darwin.tar.xz"
+      sha256 "f6627e54bfa0263f225d7947cf23e0d86dba4138016e9dd19c1c1e02bcd98132"
     end
   end
 

--- a/Formula/gear@0.3.2.rb
+++ b/Formula/gear@0.3.2.rb
@@ -14,12 +14,12 @@ class GearAT032 < Formula
   stable do
     on_arm do
       url "https://get.gear.rs/gear-v0.3.2-aarch64-apple-darwin.tar.xz"
-      sha256 "34ecf93d2714b277535c7604fde5b9e7cf63cda6b6c41f5e5ccbb984b3cb565f"
+      sha256 "bfbd45b3e5f5577f873c8da36e2a2b67a7b7f835c652736594869344749b0e65"
     end
 
     on_intel do
       url "https://get.gear.rs/gear-v0.3.2-x86_64-apple-darwin.tar.xz"
-      sha256 "d13bb988f39e4f24710d4ec97734f36e9d38721ccdb97527d81996642052c075"
+      sha256 "f6627e54bfa0263f225d7947cf23e0d86dba4138016e9dd19c1c1e02bcd98132"
     end
   end
 

--- a/scritps/add-release.sh
+++ b/scritps/add-release.sh
@@ -21,47 +21,14 @@ script_usage() {
 EOF
 }
 
-if [ "$#" -ne  "2" ]
-then
-    echo 'Error: Please provide <FORMULA> and <VERSION>'
-    script_usage
-    exit 1
-fi
+write_formula_file() {
+  FILE_NAME=$1
+  CLASS=$2
 
-if [[ "$FORMULA" != "gear" ]] && [[ "$FORMULA" != "vara" ]]; then
-    echo 'Error: <FORMULA> should be "gear" or "vara"'
-    script_usage
-    exit 1
-fi
-
-echo "$VERSION" | grep -Eq "^[0-9]+\.[0-9]+(\.[0-9]+)?$"
-
-if [ $? -ne 0 ]; then
-    echo '<VERSION> format is not correct'
-    script_usage
-    exit 1
-fi
-
-set -e
-
-SHORT_VERSION=$(echo $VERSION | sed s/\\.//g)
-FILE_NAME=$FORMULA@$VERSION.rb
-FORMULA_PREFIX="$(tr '[:lower:]' '[:upper:]' <<< ${FORMULA:0:1})${FORMULA:1}"
-
-if [[ "$FORMULA" == "vara" ]]; then
-   INFIX="testnet-"
-fi
-
-LINK_MAC_ARM="https://get.gear.rs/$FORMULA-${INFIX}v$VERSION-aarch64-apple-darwin.tar.xz"
-LINK_MAC_X86="https://get.gear.rs/$FORMULA-${INFIX}v$VERSION-x86_64-apple-darwin.tar.xz"
-
-SHA_MAC_ARM=$(curl $LINK_MAC_ARM | shasum -a 256 | head -c 64)
-SHA_MAC_X86=$(curl $LINK_MAC_X86 | shasum -a 256 | head -c 64)
-
-cat <<EOF > $FILE_NAME
+  cat <<EOF > $FILE_NAME
 #!/usr/bin/env ruby
 
-class ${FORMULA_PREFIX}AT$SHORT_VERSION < Formula
+class $CLASS < Formula
   desc "Computational Component of Polkadot Network"
   homepage "https://github.com/gear-tech/gear"
   license "GPL-3.0-or-later"
@@ -99,3 +66,43 @@ class ${FORMULA_PREFIX}AT$SHORT_VERSION < Formula
   end
 end
 EOF
+}
+
+if [ "$#" -ne  "2" ]
+then
+    echo 'Error: Please provide <FORMULA> and <VERSION>'
+    script_usage
+    exit 1
+fi
+
+if [[ "$FORMULA" != "gear" ]] && [[ "$FORMULA" != "vara" ]]; then
+    echo 'Error: <FORMULA> should be "gear" or "vara"'
+    script_usage
+    exit 1
+fi
+
+echo "$VERSION" | grep -Eq "^[0-9]+\.[0-9]+(\.[0-9]+)?$"
+
+if [ $? -ne 0 ]; then
+    echo '<VERSION> format is not correct'
+    script_usage
+    exit 1
+fi
+
+set -e
+
+SHORT_VERSION=$(echo $VERSION | sed s/\\.//g)
+FORMULA_PREFIX="$(tr '[:lower:]' '[:upper:]' <<< ${FORMULA:0:1})${FORMULA:1}"
+
+if [[ "$FORMULA" == "vara" ]]; then
+   INFIX="testnet-"
+fi
+
+LINK_MAC_ARM="https://get.gear.rs/$FORMULA-${INFIX}v$VERSION-aarch64-apple-darwin.tar.xz"
+LINK_MAC_X86="https://get.gear.rs/$FORMULA-${INFIX}v$VERSION-x86_64-apple-darwin.tar.xz"
+
+SHA_MAC_ARM=$(curl $LINK_MAC_ARM | shasum -a 256 | head -c 64)
+SHA_MAC_X86=$(curl $LINK_MAC_X86 | shasum -a 256 | head -c 64)
+
+write_formula_file "$FORMULA@$VERSION.rb" "${FORMULA_PREFIX}AT$SHORT_VERSION"
+write_formula_file "$FORMULA.rb" "$FORMULA_PREFIX"


### PR DESCRIPTION
We've updated v0.3.2 as the previous one was pre-release. Also, I have fixed the `add-release.sh` script to modify the latest release (without `@x.x.x` suffix) too.

@clearloop 